### PR TITLE
don't create duplicate ids for header items

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1230,10 +1230,10 @@ def main(md_origin, origin_type="file", website_root=None, destination=None, ima
 
     # add correct id to all headings:
     html_soup = BeautifulSoup(html_rendered, 'html.parser')
-    for h in ("h1", "h2", "h3", "h4", "h5"):
-        for header_soup_representation in html_soup.find_all(h):
-            if header_soup_representation.find('a'):
-                header_soup_representation['id'] = header_soup_representation.a['id']
+    #for h in ("h1", "h2", "h3", "h4", "h5"):
+    #    for header_soup_representation in html_soup.find_all(h):
+    #        if header_soup_representation.find('a'):
+    #            header_soup_representation['id'] = header_soup_representation.a['id']
             # ToDo: Implement these nice anchor svg icons GitHub displays next to every heading
     #       link_within_header = header_soup_representation.a
     #       link_within_header.append(BeautifulSoup(GITHUB_LINK_ANCHOR, 'html.parser').find("svg"))


### PR DESCRIPTION
When the pass of the html is made for "add correct id to all headings" it duplicates the id used on the anchor tag and uses that in the heading tag. This results in a duplicate id which is invalid HTML (and specifically for my interest, fails accessibility standards WCAG 2.2 success criterium 4.1.1 - parsing). An example of the generated duplicate id in the header tag is
````
<h1 id="user-content-converting-markdown-to-html">
  <a
    aria-hidden="true"
    class="anchor"
    href="#user-content-converting-markdown-to-html"
    id="user-content-converting-markdown-to-html"
    name="user-content-converting-markdown-to-html">
    <span aria-hidden="true" class="octicon octicon-link"></span>
  </a>
  Converting markdown to HTML
</h1>
````
Bypassing "add correct id to all headings" results in 
````
<h1>
  <a
    aria-hidden="true"
    class="anchor"
    href="#user-content-converting-markdown-to-html"
    id="user-content-converting-markdown-to-html"
    name="user-content-converting-markdown-to-html">
    <span aria-hidden="true" class="octicon octicon-link"></span>
  </a>
  Converting markdown to HTML
</h1>
````
